### PR TITLE
Changed collections to collections.abc

### DIFF
--- a/en16931/tests/test_tax.py
+++ b/en16931/tests/test_tax.py
@@ -1,5 +1,5 @@
 import pytest
-from collections import Hashable
+from collections.abc import Hashable
 
 from en16931.tax import Tax
 


### PR DESCRIPTION
Changed collections to collections.abc because Hashable moved to collections.abc.