### PR TITLE
Valid templatex

### DIFF
--- a/en16931/templates/invoice.xml
+++ b/en16931/templates/invoice.xml
@@ -13,7 +13,7 @@
   <cbc:TaxCurrencyCode>{{ invoice.currency }}</cbc:TaxCurrencyCode>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="{{ invoice.seller_party.endpoint_scheme or 'ES:VAT' }}">{{ invoice.seller_party.party_legal_entity_id }}</cbc:EndpointID>
+      <cbc:EndpointID schemeID="{{ invoice.seller_party.endpoint_scheme or '9920' }}">{{ invoice.seller_party.party_legal_entity_id }}</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>{{ invoice.seller_party.name }}</cbc:Name>
       </cac:PartyName>
@@ -23,7 +23,7 @@
         <cbc:PostalZone>{{ invoice.seller_party.postal_address.postal_zone }}</cbc:PostalZone>
         <cbc:CountrySubentity>{{ invoice.seller_party.postal_address.province }}</cbc:CountrySubentity>
         <cac:Country>
-          <cbc:IdentificationCode listID="ISO3166-1:Alpha2">{{ invoice.seller_party.postal_address.country }}</cbc:IdentificationCode>
+          <cbc:IdentificationCode>{{ invoice.seller_party.postal_address.country }}</cbc:IdentificationCode>
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
@@ -43,7 +43,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="{{ invoice.buyer_party.endpoint_scheme or 'ES:VAT' }}">{{ invoice.buyer_party.party_legal_entity_id }}</cbc:EndpointID>
+      <cbc:EndpointID schemeID="{{ invoice.buyer_party.endpoint_scheme or '9920' }}">{{ invoice.buyer_party.party_legal_entity_id }}</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>{{ invoice.buyer_party.name }}</cbc:Name>
       </cac:PartyName>
@@ -53,7 +53,7 @@
         <cbc:PostalZone>{{ invoice.buyer_party.postal_address.postal_zone }}</cbc:PostalZone>
         <cbc:CountrySubentity>{{ invoice.buyer_party.postal_address.province }}</cbc:CountrySubentity>
         <cac:Country>
-          <cbc:IdentificationCode listID="ISO3166-1:Alpha2">{{ invoice.buyer_party.postal_address.country }}</cbc:IdentificationCode>
+          <cbc:IdentificationCode>{{ invoice.buyer_party.postal_address.country }}</cbc:IdentificationCode>
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>

--- a/en16931/tests/files/invoice.xml
+++ b/en16931/tests/files/invoice.xml
@@ -11,17 +11,17 @@
   <cbc:TaxCurrencyCode>EUR</cbc:TaxCurrencyCode>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="ES:VAT">ES34626691F</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9920">ES34626691F</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>Acme Inc.</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
         <cbc:StreetName>easy street</cbc:StreetName>
         <cbc:CityName>Barcelona</cbc:CityName>
-        <cbc:CountrySubentity>Barcelona</cbc:CountrySubentity>
         <cbc:PostalZone>08080</cbc:PostalZone>
+        <cbc:CountrySubentity>Barcelona</cbc:CountrySubentity>
         <cac:Country>
-          <cbc:IdentificationCode listID="ISO3166-1:Alpha2">ES</cbc:IdentificationCode>
+          <cbc:IdentificationCode>ES</cbc:IdentificationCode>
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
@@ -41,17 +41,17 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="ES:VAT">ES34626691F</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9920">ES34626691F</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>Acme Inc.</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
         <cbc:StreetName>busy street</cbc:StreetName>
         <cbc:CityName>Barcelona</cbc:CityName>
-        <cbc:CountrySubentity>Barcelona</cbc:CountrySubentity>
         <cbc:PostalZone>08080</cbc:PostalZone>
+        <cbc:CountrySubentity>Barcelona</cbc:CountrySubentity>
         <cac:Country>
-          <cbc:IdentificationCode listID="ISO3166-1:Alpha2">ES</cbc:IdentificationCode>
+          <cbc:IdentificationCode>ES</cbc:IdentificationCode>
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>

--- a/en16931/tests/files/invoice2.xml
+++ b/en16931/tests/files/invoice2.xml
@@ -11,17 +11,17 @@
   <cbc:TaxCurrencyCode>EUR</cbc:TaxCurrencyCode>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="ES:VAT">ES34626691F</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9920">ES34626691F</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>Acme Inc.</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
         <cbc:StreetName>easy street</cbc:StreetName>
         <cbc:CityName>Barcelona</cbc:CityName>
-        <cbc:CountrySubentity>Barcelona</cbc:CountrySubentity>
         <cbc:PostalZone>08080</cbc:PostalZone>
+        <cbc:CountrySubentity>Barcelona</cbc:CountrySubentity>
         <cac:Country>
-          <cbc:IdentificationCode listID="ISO3166-1:Alpha2">ES</cbc:IdentificationCode>
+          <cbc:IdentificationCode>ES</cbc:IdentificationCode>
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
@@ -41,17 +41,17 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="ES:VAT">ES34626691F</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9920">ES34626691F</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>Acme Inc.</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
         <cbc:StreetName>busy street</cbc:StreetName>
         <cbc:CityName>Barcelona</cbc:CityName>
-        <cbc:CountrySubentity>Barcelona</cbc:CountrySubentity>
         <cbc:PostalZone>08080</cbc:PostalZone>
+        <cbc:CountrySubentity>Barcelona</cbc:CountrySubentity>
         <cac:Country>
-          <cbc:IdentificationCode listID="ISO3166-1:Alpha2">ES</cbc:IdentificationCode>
+          <cbc:IdentificationCode>ES</cbc:IdentificationCode>
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>


### PR DESCRIPTION
Updated the test invoices so that they are valid.

the listID in the IdentificationCode tag doesn't seem to be necessary.
Looks like the schemeId needs to be one of these codes: https://docs.peppol.eu/poacc/billing/3.0/codelist/eas/
