### PR TITLE
custom CustomizationId

### DIFF
--- a/en16931/invoice.py
+++ b/en16931/invoice.py
@@ -85,7 +85,7 @@ class Invoice:
 
     """
 
-    def __init__(self, invoice_id=None, currency="EUR", from_xml=False):
+    def __init__(self, invoice_id=None, customization_id=None, currency="EUR", from_xml=False):
         """Initialize an Invoice.
 
         This is the main class and entry point for creating an Invoice.
@@ -133,7 +133,7 @@ class Invoice:
         self.invoice_id = invoice_id or '1'
         self.currency = currency
         self.ubl_version_id = "2.1"
-        self.customization_id = "urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0"
+        self.customization_id = customization_id or "urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0"
         self.profile_id = "urn:fdc:peppol.eu:2017:poacc:billing:01:1.0"
         self.invoice_type_code = 380
         self._issue_date = None
@@ -180,8 +180,9 @@ class Invoice:
             xml = f.read()
         root = lxml.etree.fromstring(xml)
         invoice_id = get_from_xpath(root, "invoice_id")
+        customization_id = get_from_xpath(root, "customization_id")
         currency = get_from_xpath(root, "currency")
-        invoice = cls(invoice_id=invoice_id, currency=currency, from_xml=True)
+        invoice = cls(invoice_id=invoice_id, customization_id=customization_id, currency=currency, from_xml=True)
         invoice._original_xml = xml.decode('utf8')
         invoice.issue_date = get_from_xpath(root, "invoice_issue_date")
         invoice.due_date = get_from_xpath(root, "invoice_due_date")

--- a/en16931/invoice.py
+++ b/en16931/invoice.py
@@ -96,6 +96,8 @@ class Invoice:
         invoice_id: string (optional, default '1')
             Arbitrary string to identify the invoice.
 
+        customization_id: string (optional, default 'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0')
+
         currency: string (optional, default 'EUR')
             An ISO 4217 currency code.
 

--- a/en16931/templates/invoice.xml
+++ b/en16931/templates/invoice.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDatatypes-2" xmlns:udt="urn:un:unece:uncefact:data:specification:UnqualifiedDataTypesSchemaModule:2">
   <cbc:UBLVersionID>{{ invoice.ubl_version_id }}</cbc:UBLVersionID>
-  <cbc:CustomizationID>{{ invoice.ubl_version_id }}</cbc:CustomizationID>
+  <cbc:CustomizationID>{{ invoice.customization_id }}</cbc:CustomizationID>
   <cbc:ProfileID>{{ invoice.profile_id }}</cbc:ProfileID>
   <cbc:ID>{{ invoice.invoice_id }}</cbc:ID>
   <cbc:IssueDate>{{ invoice.issue_date.strftime("%Y-%m-%d") }}</cbc:IssueDate>
@@ -169,7 +169,7 @@
     <cbc:TaxExclusiveAmount currencyID="{{ invoice.currency }}">{{ invoice.tax_exclusive_amount }}</cbc:TaxExclusiveAmount>
     <cbc:TaxInclusiveAmount currencyID="{{ invoice.currency }}">{{ invoice.tax_inclusive_amount }}</cbc:TaxInclusiveAmount>
     {% if invoice.discount_amount.amount > 0 -%}
-      <cbc:AllowanceTotalAmount currencyID="EUR">{{ invoice.discount_amount }}</cbc:AllowanceTotalAmount>
+      <cbc:AllowanceTotalAmount currencyID="{{ invoice.currency }}">{{ invoice.discount_amount }}</cbc:AllowanceTotalAmount>
     {% endif -%}
     {% if invoice.charge_amount.amount > 0 -%}
       <cbc:ChargeTotalAmount currencyID="{{ invoice.currency }}">{{ invoice.charge_amount }}</cbc:ChargeTotalAmount>
@@ -192,7 +192,7 @@
       </cac:ClassifiedTaxCategory>
     </cac:Item>
     <cac:Price>
-      <cbc:PriceAmount currencyID="EUR">{{ line.price }}</cbc:PriceAmount>
+      <cbc:PriceAmount currencyID="{{ invoice.currency }}">{{ line.price }}</cbc:PriceAmount>
     </cac:Price>
   </cac:InvoiceLine> 
   {% endfor -%}

--- a/en16931/tests/conftest.py
+++ b/en16931/tests/conftest.py
@@ -27,14 +27,14 @@ def invoice1():
                     tax_scheme_id="ES34626691F", country="ES",
                     party_legal_entity_id="ES34626691F",
                     registration_name="Acme INc.", mail="acme@acme.io",
-                    endpoint="ES76281415Y", endpoint_scheme="ES:VAT",
+                    endpoint="ES76281415Y", endpoint_scheme="9920",
                     address="easy street", address2="3rd floor", postalzone="08080",
                     city="Barcelona", province="Barcelona")
     buyer = Entity(name="Corp Inc.", tax_scheme="VAT",
                    tax_scheme_id="ES76281415Y", country="ES",
                    party_legal_entity_id="ES76281415Y",
                    registration_name="Corp INc.", mail="corp@corp.io",
-                   endpoint="ES76281415Y", endpoint_scheme="ES:VAT",
+                   endpoint="ES76281415Y", endpoint_scheme="9920",
                    address="busy street", address2="2nd floor", postalzone="08080",
                    city="Barcelona", province="Barcelona")
     invoice.buyer_party = buyer
@@ -62,14 +62,14 @@ def invoice2():
                     tax_scheme_id="ES34626691F", country="ES",
                     party_legal_entity_id="ES34626691F",
                     registration_name="Acme INc.", mail="acme@acme.io",
-                    endpoint="ES76281415Y", endpoint_scheme="ES:VAT",
+                    endpoint="ES76281415Y", endpoint_scheme="9920",
                     address="easy street", address2="3rd floor", postalzone="08080",
                     city="Barcelona", province="Barcelona")
     buyer = Entity(name="Corp Inc.", tax_scheme="VAT",
                    tax_scheme_id="ES76281415Y", country="ES",
                    party_legal_entity_id="ES76281415Y",
                    registration_name="Corp INc.", mail="corp@corp.io",
-                   endpoint="ES76281415Y", endpoint_scheme="ES:VAT",
+                   endpoint="ES76281415Y", endpoint_scheme="9920",
                    address="busy street", address2="2nd floor", postalzone="08080",
                    city="Barcelona", province="Barcelona")
     invoice.buyer_party = buyer
@@ -96,7 +96,7 @@ def invoice3():
                     tax_scheme_id="ES34626691F", country="ES",
                     party_legal_entity_id="ES34626691F",
                     registration_name="Acme INc.", mail="acme@acme.io",
-                    endpoint="ES76281415Y", endpoint_scheme="ES:VAT",
+                    endpoint="ES76281415Y", endpoint_scheme="9920",
                     address="easy street", address2="3rd floor", postalzone="08080",
                     city="Barcelona", province="Barcelona")
     bank_info_seller = BankInfo(iban="ES661234563156", bic="AAAABBCCDDD")
@@ -105,7 +105,7 @@ def invoice3():
                    tax_scheme_id="ES76281415Y", country="ES",
                    party_legal_entity_id="ES76281415Y",
                    registration_name="Corp INc.", mail="corp@corp.io",
-                   endpoint="ES76281415Y", endpoint_scheme="ES:VAT",
+                   endpoint="ES76281415Y", endpoint_scheme="9920",
                    address="busy street", address2="2nd floor", postalzone="08080",
                    city="Barcelona", province="Barcelona")
     bank_info_buyer = BankInfo(iban="ES661234567321", bic="AAAABBCCDDD",
@@ -129,6 +129,40 @@ def invoice3():
     invoice.add_lines_from([il1, il2, il3])
     return invoice
 
+
+@pytest.fixture()
+def custom_invoice():
+    invoice = Invoice(currency="EUR", customization_id="urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0")
+    seller = Entity(name="Acme Inc.", tax_scheme="VAT",
+                    tax_scheme_id="ES34626691F", country="ES",
+                    party_legal_entity_id="ES34626691F",
+                    registration_name="Acme INc.", mail="acme@acme.io",
+                    endpoint="ES76281415Y", endpoint_scheme="9920",
+                    address="easy street", address2="3rd floor", postalzone="08080",
+                    city="Barcelona", province="Barcelona")
+    buyer = Entity(name="Corp Inc.", tax_scheme="VAT",
+                   tax_scheme_id="ES76281415Y", country="ES",
+                   party_legal_entity_id="ES76281415Y",
+                   registration_name="Corp INc.", mail="corp@corp.io",
+                   endpoint="ES76281415Y", endpoint_scheme="9920",
+                   address="busy street", address2="2nd floor", postalzone="08080",
+                   city="Barcelona", province="Barcelona")
+    invoice.buyer_party = buyer
+    invoice.seller_party = seller
+    invoice.due_date = "2018-09-11"
+    invoice.issue_date = "2018-06-11"
+    # lines
+    il1 = InvoiceLine(quantity=11, unit_code="EA", price=2,
+                      item_name='test 1', currency="EUR",
+                      tax_percent=0.21, tax_category="S")
+    il2 = InvoiceLine(quantity=2, unit_code="EA", price=25,
+                      item_name='test 2', currency="EUR",
+                      tax_percent=0.21, tax_category="S")
+    il3 = InvoiceLine(quantity=5, unit_code="EA", price=3,
+                      item_name='test 3', currency="EUR",
+                      tax_percent=0.1, tax_category="S")
+    invoice.add_lines_from([il1, il2, il3])
+    return invoice
 
 @pytest.fixture()
 def tax1():

--- a/en16931/tests/files/invoice.xml
+++ b/en16931/tests/files/invoice.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDatatypes-2" xmlns:udt="urn:un:unece:uncefact:data:specification:UnqualifiedDataTypesSchemaModule:2">
   <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
-  <cbc:CustomizationID>2.1</cbc:CustomizationID>
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
   <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
   <cbc:ID>1</cbc:ID>
   <cbc:IssueDate>2018-06-11</cbc:IssueDate>

--- a/en16931/tests/files/invoice2.xml
+++ b/en16931/tests/files/invoice2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDatatypes-2" xmlns:udt="urn:un:unece:uncefact:data:specification:UnqualifiedDataTypesSchemaModule:2">
   <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
-  <cbc:CustomizationID>2.1</cbc:CustomizationID>
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
   <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
   <cbc:ID>1</cbc:ID>
   <cbc:IssueDate>2018-06-11</cbc:IssueDate>

--- a/en16931/tests/test_invoice.py
+++ b/en16931/tests/test_invoice.py
@@ -188,6 +188,10 @@ class TestInvoiceXMLGeneration:
         out = invoice3.to_xml()
         assert len(out) > 0
 
+    def test_generates_xml_custom_invoice(self, custom_invoice):
+        out = custom_invoice.to_xml()
+        assert len(out) > 0
+
     def test_writes_xml_file_invoice1(self, invoice1):
         path = '/tmp/invoice1.xml'
         invoice1.save(path)
@@ -201,4 +205,9 @@ class TestInvoiceXMLGeneration:
     def test_writes_xml_file_invoice3_with_payment_means(self, invoice3):
         path = '/tmp/invoice3.xml'
         invoice3.save(path)
+        assert os.path.exists(path)
+
+    def test_writes_xml_file_custom_invoice(self, custom_invoice):
+        path = '/tmp/custom_invoice.xml'
+        custom_invoice.save(path)
         assert os.path.exists(path)

--- a/en16931/xpaths.py
+++ b/en16931/xpaths.py
@@ -146,6 +146,7 @@ def en16931_xpaths():
     """
     xpaths = {}
     xpaths["invoice_id"] = "/xmlns:Invoice/cbc:ID"
+    xpaths["customization_id"] = "/xmlns:Invoice/cbc:CustomizationID"
     xpaths["invoice_date"] = "/xmlns:Invoice/cbc:IssueDate"
     xpaths["invoice_issue_date"] = "/xmlns:Invoice/cbc:IssueDate"
     xpaths["invoice_due_date"] = "/xmlns:Invoice/cbc:DueDate"


### PR DESCRIPTION
Added a way to set the customization id of the invoice.
This is to replace [pull request #4](https://github.com/invinet/python-en16931/pull/4) with a sensible way of changing the customization id.